### PR TITLE
Add permit paramater of password_confirmation in sign_up_params

### DIFF
--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsCon
   private
 
     def sign_up_params
-      params.permit(:name, :email, :password)
+      params.permit(:name, :email, :password, :password_confirmation)
     end
 
     def account_update_params

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,6 +31,9 @@ module QiitaClone2019
     end
     config.api_only = true
 
+    # flashのキーをセットアップ
+    config.middleware.use ActionDispatch::Flash
+
     # cors setting for devise_token_auth
     config.middleware.use Rack::Cors do
       allow do


### PR DESCRIPTION
## Purpose
- registration_controllerでsign_up_paramsでpassword_confirmationを追加していなかったので、追加

## Issue
#4 

## References
none