### PR TITLE
記事詳細ページの実装

### DIFF
--- a/app/javascript/packs/container/ArticleDetailContainer.vue
+++ b/app/javascript/packs/container/ArticleDetailContainer.vue
@@ -1,0 +1,105 @@
+<template>
+  <div class="container">
+    <header_container></header_container>
+    <h2 class="heading">記事詳細</h2>
+      <div>
+        <h1>{{articleTitle}}</h1>
+      </div>
+      <div>
+        <div>{{articleBody}}</div>
+      </div>
+  </div>
+</template>
+
+<script lang="ts">
+  import axios from "axios"
+  import { Vue, Component } from "vue-property-decorator"
+  import VueRouter from 'vue-router'
+  import Header_container from "./Header.vue";
+
+  Vue.use(VueRouter);
+
+  const config = {
+    headers: {
+      'Authorization': 'Bearer',
+      'Access-Control-Allow-Origin': '*',
+      'access-token': localStorage.getItem('access-token'),
+      'client': localStorage.getItem('client'),
+      'uid': localStorage.getItem('uid')
+    }
+  }
+
+  @Component({
+    components: { Header_container }
+  })
+
+  export default class ArticleDetailContainer extends Vue {
+    articleTitle: string = '';
+    articleBody: string = '';
+
+    async mounted(): Promise<void> {
+      await axios.get(`/api/v1/articles/${this.$route.params.articleId}`, config).then((response) => {
+        this.articleTitle = response.data.data.attributes.title;
+        this.articleBody = response.data.data.attributes.body;
+      }).catch((error) => {
+        alert(error)
+      })
+    }
+  }
+</script>
+
+<style lang="scss">
+  .heading {
+    position: relative;
+    display: inline-block;
+    margin: 30px 0 15px;
+    padding-bottom: 15px;
+    letter-spacing: 2px;
+    font-size: 3rem;
+    align-items: center;
+  }
+  .container {
+    text-align: center;
+  }
+  .heading::before,
+  .heading::after {
+    content: '';
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    border-bottom: 1px solid #999;
+  }
+  .heading::before {
+    bottom: 5px;
+  }
+  .article__form {
+    width: 90%;
+    margin: 100px auto;
+    padding-top: 20px;
+    padding-bottom: 20px;
+    border: rgba(0,153,255,0.5) dotted 2px;
+    background-color: rgba(51,255,184,0.25);
+    display: block;
+    border-radius: 0;
+    input[type=text] {
+      width: 90%;
+      margin: 10px auto;
+      padding: 15px;
+    }
+    textarea {
+      width: 90%;
+      height: 500px;
+      display: block;
+      margin: 10px auto;
+      padding: 15px;
+    }
+    .article__form__selectBox {
+      padding: 20px;
+      select {
+        padding: 15px;
+      }
+    }
+
+  }
+</style>

--- a/app/javascript/packs/container/ArticleDetailContainer.vue
+++ b/app/javascript/packs/container/ArticleDetailContainer.vue
@@ -2,11 +2,9 @@
   <div class="container">
     <header_container></header_container>
     <h2 class="heading">記事詳細</h2>
-      <div>
+      <div class="article">
         <h1>{{articleTitle}}</h1>
-      </div>
-      <div>
-        <div>{{articleBody}}</div>
+        <div class="article-body">{{articleBody}}</div>
       </div>
   </div>
 </template>
@@ -73,7 +71,7 @@
   .heading::before {
     bottom: 5px;
   }
-  .article__form {
+  .article {
     width: 90%;
     margin: 100px auto;
     padding-top: 20px;
@@ -82,24 +80,13 @@
     background-color: rgba(51,255,184,0.25);
     display: block;
     border-radius: 0;
-    input[type=text] {
+    .article-body {
       width: 90%;
-      margin: 10px auto;
-      padding: 15px;
-    }
-    textarea {
-      width: 90%;
-      height: 500px;
+      height: 100%;
       display: block;
+      background-color: #FFF;
       margin: 10px auto;
       padding: 15px;
     }
-    .article__form__selectBox {
-      padding: 20px;
-      select {
-        padding: 15px;
-      }
-    }
-
   }
 </style>

--- a/app/javascript/packs/container/ArticlesContainer.vue
+++ b/app/javascript/packs/container/ArticlesContainer.vue
@@ -3,8 +3,14 @@
         <header_container></header_container>
         <ul>
             <li v-for="article in articles" :key="article.id">
-                <div class="article__title">{{article.title}}</div>
-                <div class="article-body">{{article.body}}</div>
+                <div class="article__title">
+                    <router-link :to="{ name: 'article_detail', params: { articleId: article.id } }">
+                        {{article.attributes.title}}
+                    </router-link>
+                </div>
+                <div class="article-body">
+                        {{article.attributes.body}}
+                </div>
             </li>
         </ul>
     </div>
@@ -43,7 +49,7 @@
     async fetchArticles(): Promise<void> {
       await axios.get("/api/v1/articles").then((response) => {
         response.data.data.map((article: any) => {
-          this.articles.push(article.attributes);
+          this.articles.push(article);
         })
       })
     }

--- a/app/javascript/packs/router/router.ts
+++ b/app/javascript/packs/router/router.ts
@@ -7,6 +7,7 @@ import CompleteUserRegistrationContainer from '../container/AfterUserRegistratio
 import PostArticleContainer from '../container/PostArticleContainer.vue'
 import MyPageContainer from '../container/MyPageContainer.vue'
 import EditArticleContainer from "../container/EditArticleContainer.vue";
+import ArticleDetailContainer from "../container/ArticleDetailContainer.vue";
 
 Vue.use(VueRouter)
 
@@ -19,6 +20,7 @@ export default new VueRouter({
     { path: '/complete_user_registration', component: CompleteUserRegistrationContainer },
     { path: '/post_articles', component: PostArticleContainer },
     { path: '/edit_articles/:articleId', name: 'edit_article', component: EditArticleContainer },
+    { path: '/article_detail/:articleId', name: 'article_detail', component: ArticleDetailContainer },
     { path: '/my_page', component: MyPageContainer },
     // 存在しないpathが指定された時はrootへredirect
     { path: '*', redirect: '/' }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   get "/complete_user_registration", to: "homes#index"
   get "/my_page", to: "homes#index"
   get "/edit_articles/:id", to: "homes#index"
+  get "/article_detail/:id", to: "homes#index"
 
   get "/activation", to: "activations#index"
 


### PR DESCRIPTION
## Purpose
- 記事の詳細ページを実装。
- 記事一覧ページから詳細ページに遷移できるように追加実装
- CSSはVuetifyなどのようなCSSフレームワークを使うので、ここでは仮で当てている。
- 記事一覧ページとマイページで記事を表示する際に、bodyを表示しないようにクライアント側を修正
(上記のバックエンド側は別PRで対応)

## Issue
#3 

## References
- https://github.com/mc-chinju/qiita_clone/pull/31
- [すぐ使えるダミーテキスト](https://lipsum.sugutsukaeru.jp/)
- [test](https://test.com)
