### PR TITLE
config/boot.rbを修正

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,4 +1,4 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
-require 'bootsnap/setup' # Speed up boot time by caching expensive operations.
+# require 'bootsnap/setup' # Speed up boot time by caching expensive operations.

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,4 +1,13 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
-# require 'bootsnap/setup' # Speed up boot time by caching expensive operations.
+
+# This code refs: https://github.com/Shopify/bootsnap/issues/77#issuecomment-443581752
+# Gather environment information
+in_console = (ARGV & ['c', 'console']).any?
+in_development = ENV['RAILS_ENV'] != 'production'
+
+# Do not use bootsnap in production console to prevent cache file permission issues
+if in_development || !in_console
+  require 'bootsnap/setup'
+end


### PR DESCRIPTION
## Purpose
- EC2上でrailsコマンドを実行すると、bootsnapでエラーするので、config/boot.rbを修正

## Issue
#8 

## References
- [【回避方法】passengerでRails5.2アプリが起動しない](https://qiita.com/NaokiIshimura/items/bf595e7d2041b1d970d1)
- https://github.com/Shopify/bootsnap/issues/77#issuecomment-443581752
- [test](https://test.com)
