### PR TITLE
本番環境でプリコンパイルする際の挙動を変更

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -13,6 +13,18 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
 
-# For normalize.css
-Rails.application.config.assets.precompile += %w( normalize.css )
-Rails.application.config.assets.precompile += %w( global.css )
+Rails.application.config.assets.precompile << Proc.new do |path|
+  if path =~ /\.(css|js)\z/
+    full_path = Rails.application.assets.resolve(path).to_path
+    app_assets_path = Rails.root.join('app', 'assets').to_path
+    if full_path.starts_with? app_assets_path
+      logger.info "including asset: " + full_path
+      true
+    else
+      logger.info "excluding asset: " + full_path
+      false
+    end
+  else
+    false
+  end
+end

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -4,7 +4,7 @@ default: &default
   source_path: app/javascript
   source_entry_path: packs
   public_root_path: public
-  public_output_path: packs
+  public_output_path: ./
   cache_path: tmp/cache/webpacker
   check_yarn_integrity: false
   webpack_compile_output: false
@@ -88,7 +88,7 @@ test:
 production:
   <<: *default
 
-  # Production depends on precompilation of packs prior to booting for performance.
+  # Production depends on pre-compilation of packs prior to booting for performance.
   compile: false
 
   # Extract and emit a css file


### PR DESCRIPTION
## Purpose
- 本番環境で全てのapp/assets配下にあるファイルをprecompileするように調整
- webpackerのassetsの出力先をpacksからpublick直下に変更

## Issue
#8 


## References
- [4.1 アセットをプリコンパイルする](https://railsguides.jp/asset_pipeline.html#%E3%82%A2%E3%82%BB%E3%83%83%E3%83%88%E3%82%92%E3%83%97%E3%83%AA%E3%82%B3%E3%83%B3%E3%83%91%E3%82%A4%E3%83%AB%E3%81%99%E3%82%8B)

