### PR TITLE
fix: update Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,8 +62,6 @@ GEM
     ast (2.4.0)
     bcrypt (3.1.12)
     bindex (0.7.0)
-    bootsnap (1.4.4)
-      msgpack (~> 1.0)
     builder (3.2.3)
     byebug (11.0.1)
     case_transform (0.2)
@@ -117,7 +115,6 @@ GEM
     mini_racer (0.2.6)
       libv8 (>= 6.9.411)
     minitest (5.11.3)
-    msgpack (1.2.10)
     mysql2 (0.5.2)
     nio4r (2.3.1)
     nokogiri (1.10.3)
@@ -280,7 +277,6 @@ PLATFORMS
 DEPENDENCIES
   active_model_serializers (~> 0.10.0)
   annotate
-  bootsnap (>= 1.1.0)
   devise
   devise-i18n
   devise_token_auth!


### PR DESCRIPTION
## Purpose
- Gemfileのbootsnapを消した際に、Gemfile.lockが更新されていなかったため、その対応
