### PR TITLE
Feature/correspond to security alearts

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "@rails/webpacker": "^4.0.2",
     "axios": "^0.19.0-beta.1",
     "highlight.js": "^9.15.8",
+    "lodash": "^4.17.13",
     "marked": "^0.6.3",
     "ts-loader": "^5.4.5",
     "typescript": "^3.4.5",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "@rails/webpacker": "^4.0.2",
     "axios": "^0.19.0-beta.1",
+    "fstream": "^1.0.12",
     "highlight.js": "^9.15.8",
     "lodash": "^4.17.13",
     "lodash.template": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "axios": "^0.19.0-beta.1",
     "highlight.js": "^9.15.8",
     "lodash": "^4.17.13",
+    "lodash.template": "^4.5.0",
     "marked": "^0.6.3",
     "ts-loader": "^5.4.5",
     "typescript": "^3.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3866,6 +3866,11 @@ lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.5, lodash@~4.17.10:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
+lodash@^4.17.13:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
 loglevel@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.1.tgz#e0fc95133b6ef276cdc8887cdaf24aa6f156f8fa"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3816,7 +3816,7 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
-lodash._reinterpolate@~3.0.0:
+lodash._reinterpolate@^3.0.0, lodash._reinterpolate@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
   integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
@@ -3847,6 +3847,14 @@ lodash.template@^4.2.4:
   integrity sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=
   dependencies:
     lodash._reinterpolate "~3.0.0"
+    lodash.templatesettings "^4.0.0"
+
+lodash.template@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-4.5.0.tgz#f976195cf3f347d0d5f52483569fe8031ccce8ab"
+  integrity sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==
+  dependencies:
+    lodash._reinterpolate "^3.0.0"
     lodash.templatesettings "^4.0.0"
 
 lodash.templatesettings@^4.0.0:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2863,6 +2863,16 @@ fstream@^1.0.0, fstream@^1.0.2:
     mkdirp ">=0.5 0"
     rimraf "2"
 
+fstream@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.12.tgz#4e8ba8ee2d48be4f7d0de505455548eae5932045"
+  integrity sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==
+  dependencies:
+    graceful-fs "^4.1.2"
+    inherits "~2.0.0"
+    mkdirp ">=0.5 0"
+    rimraf "2"
+
 function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"


### PR DESCRIPTION
## Purpose
- GitHubでSecurity Aleartsが出ていたので、対抗。

対象のライブラリは次の通り。
- lodash
- lodash.template
- fstream

## Issue
#8 

## References
https://github.com/yuta-ushijima/qiita_clone_2019/network/alerts
